### PR TITLE
FIR-214: Add reserved memory area beginning 0x56A0_000 of 512 MB and Enable NVME

### DIFF
--- a/arch/arm64/boot/dts/intel/socfpga_agilex.dtsi
+++ b/arch/arm64/boot/dts/intel/socfpga_agilex.dtsi
@@ -27,7 +27,7 @@
 		};
                 service_reserved1: svcbuffer@1 {
                         compatible = "shared-dma-pool";
-                        reg = <0x0 0x7F000000 0x0 0x7FFFFFFF>;
+                        reg = <0x0 0x56A00000 0x0 0x20000000>;
                         alignment = <0x1000>;
                         no-map;
                 };

--- a/arch/arm64/boot/dts/intel/socfpga_agilex_bittware.dts
+++ b/arch/arm64/boot/dts/intel/socfpga_agilex_bittware.dts
@@ -181,14 +181,8 @@
 	};
 };
 
-/* To test TXE blob with DDR, we need to comment out PCIE & SSD */
-#ifdef DDR_ACCESS
 &pcie_0_pcie_aglx {
 	status = "okay";
 	compatible = "altr,pcie-root-port-3.0-f-tile";
-	/* interrupts = <0 0 0>; */
-/*	interrupts = <32 IRQ_TYPE_LEVEL_HIGH>;
-	interupt_parent = <&intc>; */
 };
-#endif
 


### PR DESCRIPTION
These changes do two following changes

1.  Reserve memory region from 0x56A0_0000 for 512MB space for Model data
2. Enable NVME in DTS file