### PR TITLE
@FIR-538: Increaed u-dma-buf-0 to use full 1GB memory

### DIFF
--- a/arch/arm64/boot/dts/intel/socfpga_agilex_bittware.dtsi
+++ b/arch/arm64/boot/dts/intel/socfpga_agilex_bittware.dtsi
@@ -41,7 +41,7 @@
 	udmabuf@0 {
 		compatible = "ikwzm,u-dma-buf";
 		device-name = "udmabuf0";
-		size = <0x3E000000>; // 992 MiB
+		size = <0x40000000>; // 1GiB
 		memory-region = <&service_reserved1>;
 	};
 


### PR DESCRIPTION
This change as following
1. Updating DTSI to use full 1GB reserved memory of lower 2GB