### PR TITLE
reduced memory for udmabuf0/svcbuffer@1 to 4MB from 1GB

### DIFF
--- a/arch/arm64/boot/dts/intel/socfpga_agilex_bittware.dtsi
+++ b/arch/arm64/boot/dts/intel/socfpga_agilex_bittware.dtsi
@@ -28,7 +28,7 @@
 		service_reserved1: svcbuffer@1 {
 			compatible = "shared-dma-pool";
   			reusable;
-			reg = <0x0 0x40000000 0x0 0x400000>;
+			reg = <0x0 0x7FC00000 0x0 0x400000>;
 			alignment = <0x1000>;
 		};
 		service_reserved2: svcbuffer@2 {

--- a/arch/arm64/boot/dts/intel/socfpga_agilex_bittware.dtsi
+++ b/arch/arm64/boot/dts/intel/socfpga_agilex_bittware.dtsi
@@ -28,7 +28,7 @@
 		service_reserved1: svcbuffer@1 {
 			compatible = "shared-dma-pool";
   			reusable;
-			reg = <0x0 0x40000000 0x0 0x40000000>;
+			reg = <0x0 0x40000000 0x0 0x400000>;
 			alignment = <0x1000>;
 		};
 		service_reserved2: svcbuffer@2 {
@@ -41,7 +41,7 @@
 	udmabuf@0 {
 		compatible = "ikwzm,u-dma-buf";
 		device-name = "udmabuf0";
-		size = <0x40000000>; // 1GiB
+		size = <0x400000>; // 4MB
 		memory-region = <&service_reserved1>;
 	};
 


### PR DESCRIPTION
Description: Reduce memory reservation for CMA and provide more memory to Linux kernel.

Related PRs:
https://github.com/tsisw/common-runtime/pull/55
https://github.com/tsisw/runtime/pull/101


====

Impact Analysis:

    What is the scope of the change?
Evolutionary.

    Purpose of the change?
Reduce memory reservation for CMA and provide more memory to Linux kernel.

    Reach of the change?
FPGA, runtime, common-runtime.

Regression Test result: <Regtest result link .>


values for ~3GB reserve for CMA:

root@agilex7_dk_si_agf014eb:/tsi/dmohapatra/rtlib# cat /proc/meminfo 
MemTotal:        1985760 kB
MemFree:           32880 kB
**MemAvailable:     743580 kB**
Buffers:           57844 kB
Cached:           697184 kB
SwapCached:            0 kB
Active:            66336 kB
Inactive:         692416 kB
Active(anon):        108 kB
Inactive(anon):     3872 kB
Active(file):      66228 kB
Inactive(file):   688544 kB
Unevictable:           0 kB
Mlocked:               0 kB
SwapTotal:       2097148 kB
SwapFree:        2097148 kB
Dirty:                 0 kB
Writeback:             0 kB
AnonPages:          3780 kB
Mapped:             3512 kB
Shmem:               256 kB
KReclaimable:      36016 kB
Slab:              49252 kB
SReclaimable:      36016 kB
SUnreclaim:        13236 kB
KernelStack:        1472 kB
PageTables:         2732 kB
SecPageTables:         0 kB
NFS_Unstable:          0 kB
Bounce:                0 kB
WritebackTmp:          0 kB
CommitLimit:     3076716 kB
Committed_AS:      16536 kB
VmallocTotal:   135288315904 kB
VmallocUsed:        5544 kB
VmallocChunk:          0 kB
Percpu:              448 kB
HardwareCorrupted:     0 kB
AnonHugePages:         0 kB
ShmemHugePages:        0 kB
ShmemPmdMapped:        0 kB
FileHugePages:         0 kB
FilePmdMapped:         0 kB
**CmaTotal:        1050624 kB**
CmaFree:              64 kB
HugePages_Total:      13
HugePages_Free:       12
HugePages_Rsvd:        0
HugePages_Surp:        0
Hugepagesize:       2048 kB
Hugetlb:           26624 kB

======
values from ~2GB reserve for CMA (primarily from high -DDR)

root@agilex7_dk_si_agf014eb:~# cat /proc/meminfo
MemTotal:        1984224 kB
MemFree:           38344 kB
**MemAvailable:    1768400 kB**
Buffers:           55788 kB
Cached:          1703288 kB
SwapCached:            0 kB
Active:            64384 kB
Inactive:        1698164 kB
Active(anon):        104 kB
Inactive(anon):     3664 kB
Active(file):      64280 kB
Inactive(file):  1694500 kB
Unevictable:           0 kB
Mlocked:               0 kB
SwapTotal:       2097148 kB
SwapFree:        2097148 kB
Dirty:                 0 kB
Writeback:             0 kB
AnonPages:          3528 kB
Mapped:             3556 kB
Shmem:               252 kB
KReclaimable:      61644 kB
Slab:              77988 kB
SReclaimable:      61644 kB
SUnreclaim:        16344 kB
KernelStack:        1440 kB
PageTables:         2616 kB
SecPageTables:         0 kB
NFS_Unstable:          0 kB
Bounce:                0 kB
WritebackTmp:          0 kB
CommitLimit:     3068780 kB
Committed_AS:      16020 kB
VmallocTotal:   135288315904 kB
VmallocUsed:        5564 kB
VmallocChunk:          0 kB
Percpu:              448 kB
HardwareCorrupted:     0 kB
AnonHugePages:         0 kB
ShmemHugePages:        0 kB
ShmemPmdMapped:        0 kB
FileHugePages:         0 kB
FilePmdMapped:         0 kB
**CmaTotal:           6144 kB**
CmaFree:               0 kB
HugePages_Total:      20
HugePages_Free:       19
HugePages_Rsvd:        0
HugePages_Surp:        0
Hugepagesize:       2048 kB
Hugetlb:           40960 kB
