### PR TITLE
FIR 1660 - revert FPGA to single txe

### DIFF
--- a/arch/arm64/boot/dts/intel/socfpga_agilex_bittware.dts
+++ b/arch/arm64/boot/dts/intel/socfpga_agilex_bittware.dts
@@ -15,7 +15,6 @@
 		ethernet1 = &gmac1;
 		ethernet2 = &gmac2;
 		txe0 = &txe0;
-		txe1 = &txe1;
 
 	};
 

--- a/arch/arm64/boot/dts/intel/socfpga_agilex_bittware.dtsi
+++ b/arch/arm64/boot/dts/intel/socfpga_agilex_bittware.dtsi
@@ -693,13 +693,6 @@
 			instance-id = <0>;
                         };
 
-		txe1: txe@1 {
-			compatible = "tsi,txe";
-			status = "okay";
-			mmu_status = "disabled";
-			instance-id = <1>;
-                        };
-
 		firmware {
 			svc {
 				compatible = "intel,agilex-svc";


### PR DESCRIPTION
On FPGA since we have only single TXE, we are reverting the # of txes in DTS file to 1. 