### PR TITLE
FIR-1660: Adding mods to dts/dtsi files to revert to 1 txe for fpga -…

### DIFF
--- a/arch/arm64/boot/dts/intel/socfpga_agilex_bittware.dts
+++ b/arch/arm64/boot/dts/intel/socfpga_agilex_bittware.dts
@@ -15,7 +15,6 @@
 		ethernet1 = &gmac1;
 		ethernet2 = &gmac2;
 		txe0 = &txe0;
-		txe1 = &txe1;
 
 	};
 

--- a/arch/arm64/boot/dts/intel/socfpga_agilex_bittware.dtsi
+++ b/arch/arm64/boot/dts/intel/socfpga_agilex_bittware.dtsi
@@ -693,12 +693,6 @@
 			instance-id = <0>;
                         };
 
-		txe1: txe@1 {
-			compatible = "tsi,txe";
-			status = "okay";
-			mmu_status = "disabled";
-			instance-id = <1>;
-                        };
 
 		firmware {
 			svc {


### PR DESCRIPTION
Revert FPGA to single TXE.

Note - this goes in conjunction with the FIR-1660 PR in tsi_yocto_workspace 
Logs:



root@agilex7dksiagf014eb:/usr/bin/tsi/bin# ./run_llama_cli.sh 
 was Tim. He loved



llama_perf_sampler_print:    sampling time =      99.88 ms /    11 runs   (    9.08 ms per token,   110.13 tokens per second)
llama_perf_context_print:        load time =    1863.53 ms
llama_perf_context_print: prompt eval time =     535.34 ms /     6 tokens (   89.22 ms per token,    11.21 tokens per second)
llama_perf_context_print:        eval time =     719.16 ms /     4 runs   (  179.79 ms per token,     5.56 tokens per second)
llama_perf_context_print:       total time =    2698.74 ms /    10 tokens

=== GGML Perf Summary ===
  Op                   Runs        Total us            Avg us
  ADD                   176          449312           2552.91
  MUL                   187          377625           2019.39
  RMS_NORM              187          479468           2564.00
  MUL_MAT              2625         2108423            803.21
  CONT                  539           67062            124.42
  RESHAPE               467             437              0.94
  VIEW                  721             507              0.70
  PERMUTE               536             526              0.98
  TRANSPOSE             168             198              1.18
  GET_ROWS               68            1112             16.35
  SET_ROWS              519            3508              6.76
  SOFT_MAX              230          186558            811.12
  ROPE                  496            7227             14.57
  GLU                    88          211924           2408.23

OPU Profiling Results:
------------------------------------------------------------------------------------------------------------------------
Calls  Total(ms)    T/call    Self(ms)  Function
------------------------------------------------------------------------------------------------------------------------
    1    24.5640   24.5640     20.2880  [8.63e-01%] [Thread] tsi::runtime::TsavRTFPGA::initialize
    1     2.6730    2.6730      2.6730  └─ [9.39e-02%] tsi::runtime::TsavRTFPGA::initializeQueues
    1     0.7140    0.7140      0.7140  └─ [2.51e-02%] tsi::runtime::TsavRTFPGA::initializeRuntimeSpace
    1     0.6920    0.6920      0.6920  └─ [2.43e-02%] tsi::runtime::TsavRT::initialize
    1     0.1970    0.1970      0.1460  └─ [6.92e-03%] tsi::runtime::TsavRTFPGA::sendNOPTestCommand
    2     0.0510    0.0255      0.0510    └─ [1.79e-03%] tsi::runtime::executeWithTimeout
------------------------------------------------------------------------------------------------------------------------
[Thread] tsi::runtime::TsavRT::awaitCommandListCompletion (cumulative over all threads)
------------------------------------------------------------------------------------------------------------------------
  470   171.2710    0.3644      0.0000  [ 6.02%] [Thread] tsi::runtime::TsavRT::awaitCommandListCompletion
  470  2528.8866    5.3806   2528.8866  └─ [88.82%] TXE 0 Idle
  160    31.8551    0.1991     31.8551  └─ [ 1.12%] [ txe_mult ]
  150    29.8732    0.1992     29.8732  └─ [ 1.05%] [ txe_add ]
   85    20.0056    0.2354     20.0056  └─ [7.03e-01%] [ txe_rms_norm ]
   75    17.0088    0.2268     17.0088  └─ [5.97e-01%] [ txe_swiglu ]
------------------------------------------------------------------------------------------------------------------------
[Thread] tsi::runtime::TsavRTFPGA::finalize (cumulative over all threads)
------------------------------------------------------------------------------------------------------------------------
    1    69.7210   69.7210     10.6820  [ 2.45%] [Thread] tsi::runtime::TsavRTFPGA::finalize
    1    57.8720   57.8720     57.8720  └─ [ 2.03%] tsi::runtime::TsavRT::finalize
    1     1.1670    1.1670      1.1670  └─ [4.10e-02%] tsi::runtime::TsavRTFPGA::releaseTxes
------------------------------------------------------------------------------------------------------------------------
[Thread] OPU  (cumulative over all threads)
------------------------------------------------------------------------------------------------------------------------
    1     0.3450    0.3450      0.2760  [1.21e-02%] [Thread] OPU 
    1     0.0690    0.0690      0.0690  └─ [2.42e-03%] tsi::runtime::TsavRT::allocate
------------------------------------------------------------------------------------------------------------------------
[Thread] tsi::runtime::TsavRT::finalizeCommandList (cumulative over all threads)
------------------------------------------------------------------------------------------------------------------------
  470   422.6150    0.8992    418.7730  [14.84%] [Thread] tsi::runtime::TsavRT::finalizeCommandList
  470     3.8420    0.0082      3.8420  └─ [1.35e-01%] tsi::runtime::executeWithTimeout
------------------------------------------------------------------------------------------------------------------------
[Thread] tsi::runtime::TsavRT::processResponses (cumulative over all threads)
------------------------------------------------------------------------------------------------------------------------
  470   545.3920    1.1604     11.0640  [19.15%] [Thread] tsi::runtime::TsavRT::processResponses
  470   534.3280    1.1369    534.3280  └─ [18.77%] tsi::runtime::executeWithTimeout
------------------------------------------------------------------------------------------------------------------------
[Thread] tsi::runtime::TsavRT::allocate (cumulative over all threads)
------------------------------------------------------------------------------------------------------------------------
  472     5.2560    0.0111      5.2560  [1.85e-01%] [Thread] tsi::runtime::TsavRT::allocate
------------------------------------------------------------------------------------------------------------------------
[Thread] tsi::runtime::TsavRTFPGA::loadBlob (cumulative over all threads)
------------------------------------------------------------------------------------------------------------------------
  470   125.0670    0.2661    125.0670  [ 4.39%] [Thread] tsi::runtime::TsavRTFPGA::loadBlob
------------------------------------------------------------------------------------------------------------------------
[Thread] tsi::runtime::TsavRT::addCommandToList (cumulative over all threads)
------------------------------------------------------------------------------------------------------------------------
  470    16.6750    0.0355     16.6750  [5.86e-01%] [Thread] tsi::runtime::TsavRT::addCommandToList
------------------------------------------------------------------------------------------------------------------------
[Thread] tsi::runtime::TsavRTFPGA::unloadBlob (cumulative over all threads)
------------------------------------------------------------------------------------------------------------------------
  470    31.0240    0.0660     31.0240  [ 1.09%] [Thread] tsi::runtime::TsavRTFPGA::unloadBlob
------------------------------------------------------------------------------------------------------------------------
[Thread] tsi::runtime::TsavRT::deallocate (cumulative over all threads)
------------------------------------------------------------------------------------------------------------------------
  470     4.7350    0.0101      4.7350  [1.66e-01%] [Thread] tsi::runtime::TsavRT::deallocate
========================================================================================================================
    -  2847.2880    0.0000   2847.2880  [100.00%] TOTAL
========================================================================================================================

Counter Metrics:
------------------------------------------------------------------------------------------------------------------------
Metric                                    Min            Max            Avg
------------------------------------------------------------------------------------------------------------------------
Queue_0_Occupancy                      0.0000         1.0000         0.9343
------------------------------------------------------------------------------------------------------------------------

root@agilex7dksiagf014eb:/usr/bin/tsi/bin# cd aot-tests
root@agilex7dksiagf014eb:/usr/bin/tsi/bin/aot-tests# ./tests-torch/add/add.sh
[2025-05-30 05:21:41.839] [info] Build: 2026-04-03 18:21:09 v0.3.8 (040514c/HEAD) | Type: RelWithDebInfo | Device: FPGA
[2025-05-30 05:21:41.839] [info] Running add[f] test with 128 elements
[2025-05-30 05:21:41.839] [info] Build info: 2026-04-03 18:21:09 v0.3.8 (040514c/HEAD)
[2025-05-30 05:21:41.864] [info] Model executed successfully. Validating result...
[2025-05-30 05:21:41.864] [info] Result: PASS [relative err=0.000000e+00, relTol=1.000000e-06]

Profiling Results (add):
------------------------------------------------------------------------------------------------------------------------
Calls  Total(ms)    T/call    Self(ms)  Function
------------------------------------------------------------------------------------------------------------------------
    1    94.5510   94.5510      0.9720  [99.71%] [Thread] add
    1    68.8830   68.8830     11.3790  └─ [72.64%] tsi::runtime::TsavRTFPGA::finalize
    1    56.5660   56.5660     56.5660    └─ [59.65%] tsi::runtime::TsavRT::finalize
    1     0.9380    0.9380      0.9380    └─ [9.89e-01%] tsi::runtime::TsavRTFPGA::releaseTxes
    1    23.0340   23.0340     19.3320  └─ [24.29%] tsi::runtime::TsavRTFPGA::initialize
    1     2.5010    2.5010      2.5010    └─ [ 2.64%] tsi::runtime::TsavRTFPGA::initializeQueues
    1     0.6010    0.6010      0.6010    └─ [6.34e-01%] tsi::runtime::TsavRTFPGA::initializeRuntimeSpace
    1     0.4440    0.4440      0.4440    └─ [4.68e-01%] tsi::runtime::TsavRT::initialize
    1     0.1560    0.1560      0.1100    └─ [1.65e-01%] tsi::runtime::TsavRTFPGA::sendNOPTestCommand
    2     0.0460    0.0230      0.0460      └─ [4.85e-02%] tsi::runtime::executeWithTimeout
    1     0.8580    0.8580      0.8580  └─ [9.05e-01%] tsi::runtime::TsavRTFPGA::loadBlob
    1     0.3620    0.3620      0.0000  └─ [3.82e-01%] tsi::runtime::TsavRT::awaitCommandListCompletion
    1     1.5204    1.5204      1.5204    └─ [ 1.60%] TXE 0 Idle
    1     0.1909    0.1909      0.1909    └─ [2.01e-01%] [ txe_blob_0 ]
    1     0.1540    0.1540      0.1540  └─ [1.62e-01%] tsi::runtime::TsavRT::addCommandToList
    1     0.1180    0.1180      0.1130  └─ [1.24e-01%] tsi::runtime::TsavRT::finalizeCommandList
    1     0.0050    0.0050      0.0050    └─ [5.27e-03%] tsi::runtime::executeWithTimeout
    4     0.1150    0.0288      0.1150  └─ [1.21e-01%] tsi::runtime::TsavRT::allocate
    4     0.0310    0.0077      0.0310  └─ [3.27e-02%] tsi::runtime::TsavRT::deallocate
    1     0.0240    0.0240      0.0240  └─ [2.53e-02%] tsi::runtime::TsavRTFPGA::unloadBlob
------------------------------------------------------------------------------------------------------------------------
[Thread] tsi::runtime::TsavRT::processResponses (cumulative over all threads)
------------------------------------------------------------------------------------------------------------------------
    1     0.2330    0.2330      0.2260  [2.46e-01%] [Thread] tsi::runtime::TsavRT::processResponses
    1     0.0070    0.0070      0.0070  └─ [7.38e-03%] tsi::runtime::executeWithTimeout
========================================================================================================================
    -    94.8220    0.0000     94.8220  [100.00%] TOTAL
========================================================================================================================

Counter Metrics:
------------------------------------------------------------------------------------------------------------------------
Metric                                    Min            Max            Avg
------------------------------------------------------------------------------------------------------------------------
Queue_0_Occupancy                      0.0000         1.0000         0.3333
------------------------------------------------------------------------------------------------------------------------

root@agilex7dksiagf014eb:/usr/bin/tsi/bin/aot-tests# 
root@agilex7dksiagf014eb:/usr/bin/tsi/bin/aot-tests# uname -r
6.12.33-gfc4f3fefcf71
root@agilex7dksiagf014eb:/usr/bin/tsi/bin/aot-tests# uname -a
Linux agilex7dksiagf014eb 6.12.33-gfc4f3fefcf71 #1 SMP PREEMPT Sat Apr  4 07:45:17 PDT 2026 aarch64 GNU/Linux
root@agilex7dksiagf014eb:/usr/bin/tsi/bin/aot-tests# 

