### PR TITLE
Fir 2154 tsi skylp i2c

### DIFF
--- a/Documentation/devicetree/bindings/i2c/tsi,skylp-i2c.yaml
+++ b/Documentation/devicetree/bindings/i2c/tsi,skylp-i2c.yaml
@@ -1,0 +1,116 @@
+# SPDX-License-Identifier: (GPL-2.0-only OR BSD-2-Clause)
+%YAML 1.2
+---
+$id: http://devicetree.org/schemas/i2c/tsi,skylp-i2c.yaml#
+$schema: http://devicetree.org/meta-schemas/core.yaml#
+
+title: TSI SkyLP DWC_i2c controller
+
+maintainers:
+  - Sanjay R Mehta <smehta@tsavoritesi.com>
+
+description: |
+  Synopsys DWC_i2c v1.01a ("Advanced I2C/SMBus Controller and Target
+  Device") as instantiated on TSI SkyLP. This is a different IP
+  generation from the DW_apb_i2c described by snps,designware-i2c.yaml:
+  the register offsets and several IC_CTRL field positions differ, so
+  the two are not interchangeable and the compatibles must not be mixed.
+
+  "reg" is the controller block offset inside the parent
+  tsi,skylp-chiplet CSR window, so the parent must use
+  #address-cells = <1> and #size-cells = <1>.
+
+  The SCL/SDA pads are in the IONE IO corner, whose pad and iomode
+  registers belong to the corner's pin controller
+  (tsi,skylp-ione-pinctrl) and not to this controller. Mux them by
+  referencing a pin-configuration node from pinctrl-0; the pinctrl core
+  applies the default state before the controller probes. Without it the
+  pads stay in their reset function and every transfer NACKs.
+
+  The controller has no "interrupts" property: the driver polls
+  IC_STATUS/IC_TXFLR/IC_RXFLR. The GIC routing for this block is not yet
+  established in the SkyLP interrupt map, so a consumer cannot describe
+  it correctly yet.
+
+allOf:
+  - $ref: /schemas/i2c/i2c-controller.yaml#
+
+properties:
+  compatible:
+    const: tsi,skylp-i2c
+
+  reg:
+    maxItems: 1
+
+  clock-frequency:
+    description:
+      Desired SCL bus frequency. Selects the IC_CTRL SPEED field; the
+      SCL high/low counts themselves come from tsi,scl-hcnt and
+      tsi,scl-lcnt.
+    default: 400000
+
+  tsi,scl-hcnt:
+    $ref: /schemas/types.yaml#/definitions/uint32
+    description: |
+      IC_SCL_HCNT, the SCL high period in controller clocks.
+
+      Defaulted rather than computed because the IONE MGTCLK rate is not
+      yet established; the default is the value the RTL DV fast-mode
+      bring-up programs. Set this once the input clock is known.
+    default: 0x320
+
+  tsi,scl-lcnt:
+    $ref: /schemas/types.yaml#/definitions/uint32
+    description:
+      IC_SCL_LCNT, the SCL low period in controller clocks. Defaulted on
+      the same basis as tsi,scl-hcnt.
+    default: 0x4b0
+
+required:
+  - compatible
+  - reg
+
+unevaluatedProperties: false
+
+examples:
+  - |
+    soc {
+        #address-cells = <2>;
+        #size-cells = <2>;
+
+        chiplet@2040000000 {
+            compatible = "tsi,skylp-chiplet";
+            reg = <0x20 0x40000000 0x0 0x1c000000>;
+            tsi,chiplet-id = <0>;
+            #address-cells = <1>;
+            #size-cells = <1>;
+            ranges = <0x0 0x20 0x40000000 0x1c000000>;
+
+            pinctrl@6000000 {
+                compatible = "tsi,skylp-ione-pinctrl";
+                reg = <0x6000000 0xc380>;
+                gpio-controller;
+                #gpio-cells = <2>;
+
+                i2c0_pins: i2c0-pins {
+                    groups = "smb";
+                    function = "i2c";
+                };
+            };
+
+            i2c@6002000 {
+                compatible = "tsi,skylp-i2c";
+                reg = <0x6002000 0x100>;
+                clock-frequency = <400000>;
+                pinctrl-names = "default";
+                pinctrl-0 = <&i2c0_pins>;
+                #address-cells = <1>;
+                #size-cells = <0>;
+
+                temperature-sensor@48 {
+                    compatible = "ti,tmp75";
+                    reg = <0x48>;
+                };
+            };
+        };
+    };

--- a/drivers/i2c/busses/Kconfig
+++ b/drivers/i2c/busses/Kconfig
@@ -641,6 +641,22 @@ config I2C_DIGICOLOR
 	  This driver can also be built as a module.  If so, the module
 	  will be called i2c-digicolor.
 
+config I2C_DW_ADVANCED
+	tristate "Synopsys DWC_i2c (Advanced I2C/SMBus) controller"
+	depends on OF
+	help
+	  Say Y here if you want to use the Synopsys DWC_i2c "Advanced
+	  I2C/SMBus Controller and Target Device", as instantiated on
+	  Tsavorite SkyLP.
+
+	  This is a different IP generation from the DW_apb_i2c that
+	  I2C_DESIGNWARE_PLATFORM drives: the register offsets and several
+	  IC_CTRL field positions differ, so the two drivers are not
+	  interchangeable.
+
+	  This driver can also be built as a module.  If so, the module
+	  will be called i2c-dw-advanced.
+
 config I2C_EG20T
 	tristate "Intel EG20T PCH/LAPIS Semicon IOH(ML7213/ML7223/ML7831) I2C"
 	depends on PCI && (X86_32 || MIPS || COMPILE_TEST)

--- a/drivers/i2c/busses/Makefile
+++ b/drivers/i2c/busses/Makefile
@@ -63,6 +63,7 @@ i2c-designware-platform-$(CONFIG_I2C_DESIGNWARE_BAYTRAIL) += i2c-designware-bayt
 obj-$(CONFIG_I2C_DESIGNWARE_PCI)			+= i2c-designware-pci.o
 i2c-designware-pci-y					:= i2c-designware-pcidrv.o
 obj-$(CONFIG_I2C_DIGICOLOR)	+= i2c-digicolor.o
+obj-$(CONFIG_I2C_DW_ADVANCED)	+= i2c-dw-advanced.o
 obj-$(CONFIG_I2C_EG20T)		+= i2c-eg20t.o
 obj-$(CONFIG_I2C_EMEV2)		+= i2c-emev2.o
 obj-$(CONFIG_I2C_EXYNOS5)	+= i2c-exynos5.o

--- a/drivers/i2c/busses/i2c-dw-advanced-regs.h
+++ b/drivers/i2c/busses/i2c-dw-advanced-regs.h
@@ -1,0 +1,126 @@
+/* SPDX-License-Identifier: GPL-2.0 */
+/*
+ * Register definitions for the Synopsys DWC_i2c "Advanced I2C/SMBus
+ * Controller and Target Device" as instantiated on TSI SkyLP.
+ *
+ * This is NOT the DW_apb_i2c that drivers/i2c/busses/i2c-designware-* drives.
+ * DWC_i2c v1.01a is a later, separate IP: the register file is split into a
+ * programmable-base two-block layout, and IC_CTRL's fields sit at different
+ * bit positions from DW_apb_i2c's IC_CON. A few of the deltas, for orientation
+ * when reading this next to i2c-designware-core.h:
+ *
+ *   register        DW_apb_i2c   DWC_i2c v1.01a
+ *   IC_CON/IC_CTRL  0x00         0x24   SPEED b2:1 -> b5:4
+ *                                       TX_EMPTY_CTRL b8 -> b11
+ *                                       MASTER_MODE+SLAVE_DISABLE -> IC_OP_MODE b0
+ *   IC_TAR          0x04         0x28
+ *   IC_DATA_CMD     0x10         0x78
+ *   IC_ENABLE       0x6c         0x04   (moved into the operational block)
+ *   IC_STATUS       0x70         0xac
+ *   IC_TXFLR/RXFLR  0x74/0x78    0xb0/0xb4
+ *   IC_COMP_TYPE    0xfc         0xc8   (same value, 0x44570140 -- so the
+ *                                        magic alone does NOT tell the two
+ *                                        generations apart; IC_HCI_VERSION does)
+ *
+ * Also note DWC_i2c has ONE IC_SCL_HCNT/IC_SCL_LCNT pair selected by
+ * IC_CTRL.SPEED, where DW_apb_i2c has SS/FS/HS triplets.
+ *
+ * Offsets and reset values are from the RTL-generated RAL
+ * (skylp/flex_register_macros.h, skylp/flex_ral_reset_defaults_ione.c) and
+ * cross-checked against DWC_i2c_databook.pdf v1.01a-lca00 and the SCU
+ * testbench C tests (i2c0_fast_mode_bringup.c).
+ */
+
+#ifndef __I2C_DW_ADVANCED_REGS_H__
+#define __I2C_DW_ADVANCED_REGS_H__
+
+/* Operational block -- fixed at offset 0 in the register file. */
+#define DWA_IC_HCI_VERSION		0x00
+#define DWA_IC_ENABLE			0x04
+#define DWA_IC_RESET_CTRL		0x08
+#define DWA_IC_CAPABILITIES		0x0c
+#define DWA_IC_I2C_CAPABILITIES		0x10
+#define DWA_IC_I2C_BLOCK_OFFSET		0x14
+
+/*
+ * I2C block -- relative to the value programmed into IC_I2C_BLOCK_OFFSET.
+ * That register is writable and reads 0x20 out of reset; RAL's published
+ * absolute offsets assume 0x20, and the driver programs it explicitly.
+ */
+#define DWA_I2C_BLOCK_DEFAULT_OFFSET	0x20
+
+#define DWA_IC_I2C_CORE_HEADER		0x00
+#define DWA_IC_CTRL			0x04
+#define DWA_IC_TAR			0x08
+#define DWA_IC_DAR			0x0c
+#define DWA_IC_HS_CADDR			0x10
+#define DWA_IC_UFM_TBUF_CNT		0x20
+#define DWA_IC_SCL_HCNT			0x24
+#define DWA_IC_SCL_LCNT			0x28
+#define DWA_IC_HS_SCL_HCNT		0x2c
+#define DWA_IC_HS_SCL_LCNT		0x30
+#define DWA_IC_SDA_HOLD			0x34
+#define DWA_IC_SPKLEN			0x3c
+#define DWA_IC_HS_SPKLEN		0x40
+#define DWA_IC_REG_TIMEOUT_RST		0x50
+#define DWA_IC_DATA_CMD			0x58
+#define DWA_IC_RX_TL			0x5c
+#define DWA_IC_TX_TL			0x60
+#define DWA_IC_INTR_STAT		0x74
+#define DWA_IC_INTR_MASK		0x78
+#define DWA_IC_INTR_RAW_STAT		0x7c
+#define DWA_IC_INTR_CLR			0x80
+#define DWA_IC_ENABLE_STATUS		0x84
+#define DWA_IC_TX_TRMNT_SOURCE		0x88
+#define DWA_IC_STATUS			0x8c
+#define DWA_IC_TXFLR			0x90
+#define DWA_IC_RXFLR			0x94
+#define DWA_IC_COMP_VERSION		0xa4
+#define DWA_IC_COMP_TYPE		0xa8
+
+/* IC_CTRL fields (databook Table 7-14). */
+#define DWA_IC_CTRL_OP_MODE		BIT(0)	/* 1 = controller, 0 = target */
+#define DWA_IC_CTRL_SPEED_SHIFT		4
+#define DWA_IC_CTRL_SPEED_MASK		GENMASK(5, 4)
+#define DWA_IC_CTRL_SPEED_STANDARD	(1 << DWA_IC_CTRL_SPEED_SHIFT)
+#define DWA_IC_CTRL_SPEED_FAST		(2 << DWA_IC_CTRL_SPEED_SHIFT)
+#define DWA_IC_CTRL_SPEED_HIGH		(3 << DWA_IC_CTRL_SPEED_SHIFT)
+#define DWA_IC_CTRL_10BITADDR_TGT	BIT(8)
+#define DWA_IC_CTRL_10BITADDR_CTRLR	BIT(9)
+#define DWA_IC_CTRL_STOP_DET_IFADDRESSED	BIT(10)
+#define DWA_IC_CTRL_TX_EMPTY_CTRL	BIT(11)
+#define DWA_IC_CTRL_RX_FIFO_FULL_HLD	BIT(12)
+#define DWA_IC_CTRL_STOP_DET_IF_ACTIVE	BIT(13)
+
+/* IC_DATA_CMD -- same bit positions as DW_apb_i2c. */
+#define DWA_IC_DATA_CMD_DAT_MASK	GENMASK(7, 0)
+#define DWA_IC_DATA_CMD_CMD		BIT(8)	/* 1 = read, 0 = write */
+#define DWA_IC_DATA_CMD_STOP		BIT(9)
+#define DWA_IC_DATA_CMD_RESTART		BIT(10)
+
+/* IC_STATUS -- same bit positions as DW_apb_i2c. */
+#define DWA_IC_STATUS_ACTIVITY		BIT(0)
+#define DWA_IC_STATUS_TFNF		BIT(1)
+#define DWA_IC_STATUS_TFE		BIT(2)
+#define DWA_IC_STATUS_RFNE		BIT(3)
+#define DWA_IC_STATUS_RFF		BIT(4)
+#define DWA_IC_STATUS_CTRLR_ACTIVITY	BIT(5)
+
+/* IC_TX_TRMNT_SOURCE. Bits 0 and 3 match DW_apb_i2c's IC_TX_ABRT_SOURCE. */
+#define DWA_TRMNT_7B_ADDR_NOACK		BIT(0)
+#define DWA_TRMNT_10ADDR1_NOACK		BIT(1)
+#define DWA_TRMNT_10ADDR2_NOACK		BIT(2)
+#define DWA_TRMNT_TXDATA_NOACK		BIT(3)
+#define DWA_TRMNT_GCALL_NOACK		BIT(4)
+#define DWA_TRMNT_CTRLR_DIS		BIT(11)
+#define DWA_TRMNT_ARB_LOST		BIT(12)
+#define DWA_TRMNT_ADDR_NOACK_MASK \
+	(DWA_TRMNT_7B_ADDR_NOACK | DWA_TRMNT_10ADDR1_NOACK | \
+	 DWA_TRMNT_10ADDR2_NOACK)
+
+#define DWA_IC_ENABLE_EN		BIT(0)
+
+/* Expected identity. */
+#define DWA_IC_COMP_TYPE_VALUE		0x44570140
+
+#endif /* __I2C_DW_ADVANCED_REGS_H__ */

--- a/drivers/i2c/busses/i2c-dw-advanced.c
+++ b/drivers/i2c/busses/i2c-dw-advanced.c
@@ -1,0 +1,439 @@
+// SPDX-License-Identifier: GPL-2.0
+/*
+ * Synopsys DWC_i2c ("Advanced I2C/SMBus Controller") driver for TSI SkyLP.
+ *
+ * Why this is not a variant of i2c-designware-platdrv
+ * ---------------------------------------------------
+ * The existing i2c-designware-* driver targets DW_apb_i2c. SkyLP instantiates
+ * DWC_i2c v1.01a, a later and separate Synopsys IP. Every register offset
+ * differs, and three differences are semantic rather than positional, so a
+ * regmap offset-translation on top of the existing driver cannot express them:
+ *
+ *   1. IC_CON's SPEED field moved from bits 2:1 to IC_CTRL bits 5:4, and the
+ *      upper control bits all shifted by three.
+ *   2. MASTER_MODE (b0) + SLAVE_DISABLE (b6) collapsed into one IC_OP_MODE bit.
+ *   3. The SS/FS/HS SCL count triplets collapsed into a single
+ *      IC_SCL_HCNT/IC_SCL_LCNT pair selected by IC_CTRL.SPEED.
+ *
+ * What IS reused is the algorithm: the transfer loop below follows
+ * i2c-designware-master.c's structure (fill IC_DATA_CMD, drain IC_RXFLR,
+ * decode the abort/termination source on failure), with the register layer
+ * replaced.
+ *
+ * Polled, not interrupt-driven
+ * ----------------------------
+ * The GIC routing for this controller is not yet established (it is one of the
+ * open interrupt fields in the SkyLP chiplet layout), and the DWC_i2c v1.01a
+ * interrupt bit positions are not established from the RTL-generated RAL
+ * either. Rather than guess, this driver polls IC_STATUS/IC_TXFLR/IC_RXFLR --
+ * which is also all the vFlex behavioural model implements. Interrupt support
+ * lands together with the routing.
+ *
+ * Pin muxing belongs to pinctrl, not here
+ * ---------------------------------------
+ * The SCL/SDA pads live in the IONE IO corner, whose pad and iomode registers
+ * are owned by pinctrl-tsi (tsi,skylp-ione-pinctrl). Muxing them is a
+ * "groups = \"smb\"; function = \"i2c\"" pin-configuration node referenced from
+ * this controller's pinctrl-0; the pinctrl core applies that default state
+ * before probe runs, so there is nothing to do here.
+ *
+ * Copyright (c) 2026 Tsavorite Scalable Intelligence
+ */
+
+#include <linux/bits.h>
+#include <linux/delay.h>
+#include <linux/err.h>
+#include <linux/i2c.h>
+#include <linux/io.h>
+#include <linux/iopoll.h>
+#include <linux/module.h>
+#include <linux/of.h>
+#include <linux/platform_device.h>
+#include <linux/property.h>
+
+#include "i2c-dw-advanced-regs.h"
+
+#define DWA_DRV_NAME		"i2c-dw-advanced"
+
+/*
+ * Fast-mode SCL counts. These are the values the RTL DV bring-up
+ * (i2c0_fast_mode_bringup.c) programs and the silicon is validated against.
+ *
+ * They are used verbatim rather than computed from the input clock because
+ * the IONE MGTCLK rate is not yet established. Computing from a guessed clock
+ * would silently produce a wrong bus speed; using the known-good constants and
+ * saying so does not. Device tree can override via tsi,scl-hcnt / tsi,scl-lcnt
+ * once the clock is known.
+ */
+#define DWA_DEFAULT_SCL_HCNT	0x320
+#define DWA_DEFAULT_SCL_LCNT	0x4b0
+#define DWA_DEFAULT_SDA_HOLD	0x40
+#define DWA_DEFAULT_SPKLEN	0x1
+
+/*
+ * Poll bounds. Generous: under tsisim every register access is a socket
+ * round trip to the behavioural model, not a bus cycle.
+ */
+#define DWA_ENABLE_TIMEOUT_US	100000
+#define DWA_XFER_TIMEOUT_US	500000
+#define DWA_POLL_INTERVAL_US	10
+
+struct dwa_i2c_dev {
+	struct device		*dev;
+	void __iomem		*base;		/* controller register file */
+	struct i2c_adapter	adap;
+	u32			blk;		/* IC_I2C_BLOCK_OFFSET value */
+	u32			scl_hcnt;
+	u32			scl_lcnt;
+	u32			bus_freq_hz;
+	/*
+	 * Target address the controller is currently programmed for, or
+	 * DWA_ADDR_UNCONFIGURED. Kept across transfers so a repeated transfer
+	 * to the same device skips the disable/program/enable cycle: that
+	 * cycle is 11 register accesses, and under tsisim every access is a
+	 * socket round trip to the behavioural model. For a 1 Hz sensor poll
+	 * it was 40% of all traffic.
+	 *
+	 * Invalidated on any error, so a failed transfer always reprograms
+	 * from scratch rather than inheriting whatever state it left behind.
+	 */
+	u16			cfg_addr;
+};
+
+#define DWA_ADDR_UNCONFIGURED	0xffff
+
+/* Operational-block accessors: fixed at offset 0. */
+static inline u32 dwa_op_read(struct dwa_i2c_dev *d, u32 off)
+{
+	return readl(d->base + off);
+}
+
+static inline void dwa_op_write(struct dwa_i2c_dev *d, u32 off, u32 val)
+{
+	writel(val, d->base + off);
+}
+
+/* I2C-block accessors: relative to the programmable block base. */
+static inline u32 dwa_read(struct dwa_i2c_dev *d, u32 off)
+{
+	return readl(d->base + d->blk + off);
+}
+
+static inline void dwa_write(struct dwa_i2c_dev *d, u32 off, u32 val)
+{
+	writel(val, d->base + d->blk + off);
+}
+
+static int dwa_wait_enable_state(struct dwa_i2c_dev *d, bool want_enabled)
+{
+	u32 val;
+
+	return readl_poll_timeout(d->base + d->blk + DWA_IC_ENABLE_STATUS,
+				  val,
+				  !!(val & DWA_IC_ENABLE_EN) == want_enabled,
+				  DWA_POLL_INTERVAL_US, DWA_ENABLE_TIMEOUT_US);
+}
+
+static int dwa_disable(struct dwa_i2c_dev *d)
+{
+	dwa_op_write(d, DWA_IC_ENABLE, 0);
+	return dwa_wait_enable_state(d, false);
+}
+
+static int dwa_enable(struct dwa_i2c_dev *d)
+{
+	dwa_op_write(d, DWA_IC_ENABLE, DWA_IC_ENABLE_EN);
+	return dwa_wait_enable_state(d, true);
+}
+
+static u32 dwa_speed_bits(u32 bus_freq_hz)
+{
+	if (bus_freq_hz > I2C_MAX_FAST_MODE_PLUS_FREQ)
+		return DWA_IC_CTRL_SPEED_HIGH;
+	if (bus_freq_hz > I2C_MAX_STANDARD_MODE_FREQ)
+		return DWA_IC_CTRL_SPEED_FAST;
+	return DWA_IC_CTRL_SPEED_STANDARD;
+}
+
+/*
+ * Bring the controller up in controller mode at the configured speed and
+ * target address. Mirrors the DV bring-up order: disable, program, enable.
+ * Every I2C-block register is write-protected while enabled.
+ */
+static int dwa_configure(struct dwa_i2c_dev *d, u16 target_addr)
+{
+	u32 ctrl;
+	int ret;
+
+	ret = dwa_disable(d);
+	if (ret) {
+		dev_err(d->dev, "controller stuck enabled\n");
+		return ret;
+	}
+
+	ctrl = DWA_IC_CTRL_OP_MODE | dwa_speed_bits(d->bus_freq_hz) |
+	       DWA_IC_CTRL_TX_EMPTY_CTRL;
+	dwa_write(d, DWA_IC_CTRL, ctrl);
+	dwa_write(d, DWA_IC_TAR, target_addr & 0x3ff);
+	dwa_write(d, DWA_IC_SCL_HCNT, d->scl_hcnt);
+	dwa_write(d, DWA_IC_SCL_LCNT, d->scl_lcnt);
+	dwa_write(d, DWA_IC_SDA_HOLD, DWA_DEFAULT_SDA_HOLD);
+	dwa_write(d, DWA_IC_SPKLEN, DWA_DEFAULT_SPKLEN);
+
+	/* Polled driver: keep every source masked. */
+	dwa_write(d, DWA_IC_INTR_MASK, 0);
+
+	return dwa_enable(d);
+}
+
+/* Map a termination cause onto an errno the I2C core understands. */
+static int dwa_trmnt_to_errno(struct dwa_i2c_dev *d, u32 trmnt)
+{
+	if (trmnt & DWA_TRMNT_ADDR_NOACK_MASK) {
+		dev_dbg(d->dev, "address NACK (IC_TX_TRMNT_SOURCE 0x%08x)\n",
+			trmnt);
+		return -ENXIO;
+	}
+	if (trmnt & DWA_TRMNT_TXDATA_NOACK) {
+		dev_dbg(d->dev, "data NACK (IC_TX_TRMNT_SOURCE 0x%08x)\n",
+			trmnt);
+		return -EIO;
+	}
+	if (trmnt & DWA_TRMNT_ARB_LOST) {
+		dev_dbg(d->dev, "arbitration lost\n");
+		return -EAGAIN;
+	}
+	dev_dbg(d->dev, "transfer terminated, IC_TX_TRMNT_SOURCE 0x%08x\n",
+		trmnt);
+	return -EIO;
+}
+
+/* Wait for the controller to go idle with the TX FIFO drained. */
+static int dwa_wait_idle(struct dwa_i2c_dev *d)
+{
+	u32 status;
+	int ret;
+
+	ret = readl_poll_timeout(d->base + d->blk + DWA_IC_STATUS, status,
+				 !(status & (DWA_IC_STATUS_ACTIVITY |
+					     DWA_IC_STATUS_CTRLR_ACTIVITY)) &&
+				 (status & DWA_IC_STATUS_TFE),
+				 DWA_POLL_INTERVAL_US, DWA_XFER_TIMEOUT_US);
+	if (ret)
+		dev_err(d->dev, "timeout waiting for idle (IC_STATUS 0x%08x)\n",
+			readl(d->base + d->blk + DWA_IC_STATUS));
+	return ret;
+}
+
+/* Issue one IC_DATA_CMD and wait for it to retire. */
+static int dwa_issue(struct dwa_i2c_dev *d, u32 cmd)
+{
+	u32 trmnt;
+	int ret;
+
+	dwa_write(d, DWA_IC_DATA_CMD, cmd);
+
+	ret = dwa_wait_idle(d);
+	if (ret)
+		return ret;
+
+	trmnt = dwa_read(d, DWA_IC_TX_TRMNT_SOURCE);
+	if (trmnt)
+		return dwa_trmnt_to_errno(d, trmnt);
+
+	return 0;
+}
+
+static int dwa_read_byte(struct dwa_i2c_dev *d, u8 *out)
+{
+	u32 rxflr;
+	int ret;
+
+	ret = readl_poll_timeout(d->base + d->blk + DWA_IC_RXFLR, rxflr,
+				 rxflr > 0, DWA_POLL_INTERVAL_US,
+				 DWA_XFER_TIMEOUT_US);
+	if (ret) {
+		dev_err(d->dev, "timeout waiting for RX data\n");
+		return ret;
+	}
+
+	*out = dwa_read(d, DWA_IC_DATA_CMD) & DWA_IC_DATA_CMD_DAT_MASK;
+	return 0;
+}
+
+static int dwa_xfer_msg(struct dwa_i2c_dev *d, struct i2c_msg *msg, bool last)
+{
+	bool is_read = !!(msg->flags & I2C_M_RD);
+	int ret;
+	u16 i;
+
+	for (i = 0; i < msg->len; i++) {
+		u32 cmd = is_read ? DWA_IC_DATA_CMD_CMD : msg->buf[i];
+
+		/* STOP goes on the final byte of the final message only. */
+		if (last && i == msg->len - 1)
+			cmd |= DWA_IC_DATA_CMD_STOP;
+
+		ret = dwa_issue(d, cmd);
+		if (ret)
+			return ret;
+
+		if (is_read) {
+			ret = dwa_read_byte(d, &msg->buf[i]);
+			if (ret)
+				return ret;
+		}
+	}
+	return 0;
+}
+
+static int dwa_xfer(struct i2c_adapter *adap, struct i2c_msg *msgs, int num)
+{
+	struct dwa_i2c_dev *d = i2c_get_adapdata(adap);
+	int ret = 0;
+	int i;
+
+	for (i = 0; i < num; i++) {
+		if (msgs[i].flags & I2C_M_TEN) {
+			dev_dbg(d->dev, "10-bit addressing not supported\n");
+			return -EOPNOTSUPP;
+		}
+
+		/*
+		 * IC_TAR is write-protected while enabled, so a change of
+		 * target needs a disable/program/enable cycle. Both messages
+		 * within one transfer and successive transfers to the same
+		 * device skip it -- see cfg_addr.
+		 */
+		if (msgs[i].addr != d->cfg_addr) {
+			ret = dwa_configure(d, msgs[i].addr);
+			if (ret)
+				goto out_err;
+			d->cfg_addr = msgs[i].addr;
+		}
+
+		ret = dwa_xfer_msg(d, &msgs[i], i == num - 1);
+		if (ret)
+			goto out_err;
+	}
+
+	return num;
+
+out_err:
+	/*
+	 * Force a full reprogram next time. Disabling the controller is also
+	 * what clears any half-finished transaction and the FIFOs, so the next
+	 * dwa_configure() doubles as the recovery path.
+	 */
+	d->cfg_addr = DWA_ADDR_UNCONFIGURED;
+	return ret;
+}
+
+static u32 dwa_func(struct i2c_adapter *adap)
+{
+	return I2C_FUNC_I2C | I2C_FUNC_SMBUS_EMUL;
+}
+
+static const struct i2c_algorithm dwa_algo = {
+	.xfer = dwa_xfer,
+	.functionality = dwa_func,
+};
+
+static int dwa_probe(struct platform_device *pdev)
+{
+	struct device *dev = &pdev->dev;
+	struct dwa_i2c_dev *d;
+	u32 comp_type, hci_version;
+	int ret;
+
+	d = devm_kzalloc(dev, sizeof(*d), GFP_KERNEL);
+	if (!d)
+		return -ENOMEM;
+
+	d->dev = dev;
+	d->cfg_addr = DWA_ADDR_UNCONFIGURED;
+
+	d->base = devm_platform_ioremap_resource(pdev, 0);
+	if (IS_ERR(d->base))
+		return PTR_ERR(d->base);
+
+	if (device_property_read_u32(dev, "clock-frequency", &d->bus_freq_hz))
+		d->bus_freq_hz = I2C_MAX_FAST_MODE_FREQ;
+
+	if (device_property_read_u32(dev, "tsi,scl-hcnt", &d->scl_hcnt))
+		d->scl_hcnt = DWA_DEFAULT_SCL_HCNT;
+	if (device_property_read_u32(dev, "tsi,scl-lcnt", &d->scl_lcnt))
+		d->scl_lcnt = DWA_DEFAULT_SCL_LCNT;
+
+	/*
+	 * Establish the I2C block base before any I2C-block access. It reads
+	 * 0x20 out of reset, but the DV bring-up writes it explicitly and so
+	 * does this driver -- the register is writable, so a prior user could
+	 * have moved it.
+	 */
+	dwa_op_write(d, DWA_IC_I2C_BLOCK_OFFSET, DWA_I2C_BLOCK_DEFAULT_OFFSET);
+	d->blk = dwa_op_read(d, DWA_IC_I2C_BLOCK_OFFSET) & 0xff;
+	if (d->blk != DWA_I2C_BLOCK_DEFAULT_OFFSET) {
+		dev_err(dev, "IC_I2C_BLOCK_OFFSET reads 0x%02x, expected 0x%02x\n",
+			d->blk, DWA_I2C_BLOCK_DEFAULT_OFFSET);
+		return -ENODEV;
+	}
+
+	ret = dwa_disable(d);
+	if (ret) {
+		dev_err(dev, "controller does not respond to IC_ENABLE\n");
+		return ret;
+	}
+
+	comp_type = dwa_read(d, DWA_IC_COMP_TYPE);
+	if (comp_type != DWA_IC_COMP_TYPE_VALUE) {
+		dev_err(dev, "bad IC_COMP_TYPE 0x%08x (expected 0x%08x)\n",
+			comp_type, DWA_IC_COMP_TYPE_VALUE);
+		return -ENODEV;
+	}
+
+	/*
+	 * IC_COMP_TYPE is identical on DW_apb_i2c, so it cannot tell the two
+	 * generations apart. IC_HCI_VERSION exists only on DWC_i2c and reads
+	 * 0x100 here; log it so a mis-targeted driver is obvious in dmesg.
+	 */
+	hci_version = dwa_op_read(d, DWA_IC_HCI_VERSION);
+	dev_info(dev, "DWC_i2c HCI version 0x%08x, COMP_VERSION 0x%08x\n",
+		 hci_version, dwa_read(d, DWA_IC_COMP_VERSION));
+
+	i2c_set_adapdata(&d->adap, d);
+	strscpy(d->adap.name, "TSI SkyLP DWC_i2c adapter", sizeof(d->adap.name));
+	d->adap.owner = THIS_MODULE;
+	d->adap.algo = &dwa_algo;
+	d->adap.dev.parent = dev;
+	d->adap.dev.of_node = dev->of_node;
+
+	platform_set_drvdata(pdev, d);
+
+	ret = devm_i2c_add_adapter(dev, &d->adap);
+	if (ret)
+		return ret;
+
+	dev_info(dev, "%u Hz, SCL hcnt/lcnt %u/%u, polled\n",
+		 d->bus_freq_hz, d->scl_hcnt, d->scl_lcnt);
+	return 0;
+}
+
+static const struct of_device_id dwa_of_match[] = {
+	{ .compatible = "tsi,skylp-i2c" },
+	{ }
+};
+MODULE_DEVICE_TABLE(of, dwa_of_match);
+
+static struct platform_driver dwa_driver = {
+	.probe = dwa_probe,
+	.driver = {
+		.name = DWA_DRV_NAME,
+		.of_match_table = dwa_of_match,
+	},
+};
+module_platform_driver(dwa_driver);
+
+MODULE_AUTHOR("Sanjay R Mehta <smehta@tsavoritesi.com>");
+MODULE_DESCRIPTION("Synopsys DWC_i2c (Advanced I2C/SMBus) driver for TSI SkyLP");
+MODULE_LICENSE("GPL");


### PR DESCRIPTION
[FIR-2154] Add Synopsys DWC_i2c (Advanced I2C/SMBus) driver for TSI SkyLP

SkyLP instantiates Synopsys DWC_i2c v1.01a ("Advanced I2C/SMBus
Controller and Target Device"), not the DW_apb_i2c that
drivers/i2c/busses/i2c-designware-* drives. These are separate IP
generations: every register offset differs, and three of the deltas are
semantic rather than positional, so an offset translation layered onto
the existing driver cannot express them:

  - IC_CON's SPEED field moved from bits 2:1 to IC_CTRL bits 5:4, and
    the control bits above it all shifted by three.
  - MASTER_MODE (b0) and SLAVE_DISABLE (b6) collapsed into a single
    IC_OP_MODE bit.
  - The SS/FS/HS SCL count triplets collapsed into one IC_SCL_HCNT /
    IC_SCL_LCNT pair selected by IC_CTRL.SPEED.

IC_COMP_TYPE reads the same 0x44570140 on both generations, so it cannot
tell them apart on its own; probe also reads IC_HCI_VERSION, which
exists only on DWC_i2c.

What is reused is the algorithm rather than the register layer: the
transfer loop follows i2c-designware-master.c (fill IC_DATA_CMD, drain
IC_RXFLR, decode the abort and termination source on failure).

Pin muxing is left to pinctrl-tsi. The SCL/SDA pads sit in the IONE IO
corner, whose iomode and pad-control registers that driver owns, so this
one takes a single reg range covering the controller block and expects
its pads to arrive already muxed via pinctrl-0. The pinctrl core applies
the default state before probe runs, so there is nothing to do here.

The driver polls IC_STATUS/IC_TXFLR/IC_RXFLR rather than taking
interrupts. The GIC routing for this controller is not yet established,
and the DWC_i2c v1.01a interrupt bit positions are not established from
the RTL-generated RAL either; guessing either would be worse than
polling. Interrupt support lands together with the routing.

Register offsets and reset values are from the RTL-generated RAL
(skylp/flex_register_macros.h, skylp/flex_ral_reset_defaults_ione.c),
cross-checked against DWC_i2c_databook.pdf v1.01a-lca00 and the SCU
testbench C tests.

[FIR-2154]: https://tsavoritesi.atlassian.net/browse/FIR-2154?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Implements FIR-2154: adds a driver and DT binding for the Synopsys DWC_i2c v1.01a controller on TSI SkyLP. This IP differs from the DW_apb_i2c that the existing `i2c-designware-*` drivers handle — register offsets and three field semantics changed — so the new driver reuses the transfer algorithm from `i2c-designware-master.c` behind a new register layer.

**Driver**
- Polls status and FIFO registers instead of using interrupts; GIC routing for the block is not established yet.
- Reads `IC_HCI_VERSION` at probe to disambiguate from DW_apb_i2c, since `IC_COMP_TYPE` matches on both generations.
- Skips a disable/program/enable cycle when consecutive messages target the same address.
- Defaults SCL counts to the DV bring-up constants until the IONE MGTCLK rate is known.

**DT binding**
- Adds `tsi,skylp-i2c` with a single reg range inside the chiplet CSR window.
- SCL/SDA pads are muxed via `pinctrl-0` referencing `tsi,skylp-ione-pinctrl`.
- `clock-frequency` picks the speed mode; `tsi,scl-hcnt` / `tsi,scl-lcnt` set SCL timing.

<sup>Written for commit 34948145e5e12872a8635544778a18eed0e20554. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/tsisw/linux-socfpga/pull/24?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

